### PR TITLE
Lazy loading simplemde when it is running in the browser.

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -19,13 +19,8 @@
       "testTsconfig": "tsconfig.spec.json",
       "prefix": "app",
       "styles": [
-        "styles.css",        
-        "../node_modules/simplemde/dist/simplemde.min.css"   
-      ],
-      "scripts": [
-          "../node_modules/jquery/dist/jquery.min.js",          
-          "../node_modules/simplemde/dist/simplemde.min.js",
-          "../node_modules/uploadcare-widget/uploadcare.min.js"
+        "styles.css",
+        "../node_modules/simplemde/dist/simplemde.min.css"
       ],
       "environmentSource": "environments/environment.ts",
       "environments": {

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /dist
 /tmp
 /out-tsc
+yarn*
 
 # dependencies
 /node_modules

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,33 +1,32 @@
-import { Component, OnInit, AfterViewInit, ElementRef, ViewChild,Inject } from '@angular/core';
-import { ActivatedRoute, Router, Params } from '@angular/router';
+import { Component, OnInit, AfterViewInit, ElementRef, ViewChild, Inject } from '@angular/core';
 import { PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
-
-var SimpleMDE = require('simplemde');
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
   styleUrls: ['./app.component.css']
 })
-export class AppComponent implements AfterViewInit{  
-  @ViewChild('simpleMDE') textarea : ElementRef;
+export class AppComponent implements AfterViewInit {
+  @ViewChild('simpleMDE') textarea: ElementRef;
+
+  public simplemde;
 
   constructor(private elementRef: ElementRef,
-    private activated_route: ActivatedRoute,    
     @Inject(PLATFORM_ID) private platformId: Object
-    ) { }
+  ) { }
 
-
-  public simplemde;  
-
-  ngAfterViewInit() {  
-    this.simplemde = new SimpleMDE(
-      {
-         element: this.textarea.nativeElement.value,                
-      }
-    );
+  ngAfterViewInit() {
+    if (this.platformId === 'browser') {
+      System.import('simplemde').then(SimpleMDE => {
+        this.simplemde = new SimpleMDE(
+          {
+            element: this.textarea.nativeElement.value,
+          }
+        );
+      });
+    }
   }
 }
-    
-    
+
+

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,22 +1,20 @@
+/// <reference path="../typings.d.ts" />
+
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
-import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
-
 import { AppComponent } from './app.component';
-
-
 
 @NgModule({
   declarations: [
-    AppComponent,        
+    AppComponent,
   ],
   imports: [
     BrowserModule.withServerTransition({ appId: 'universal' }),
     FormsModule,
-    HttpModule,    
+    HttpModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -6,3 +6,4 @@ interface NodeModule {
   id: string;
 }
 
+declare var System: any;


### PR DESCRIPTION
You can't render the SimpleMDE editor in the server, because it depends on the browser, but you can render your app normally with SSR and lazy load the simplemde library only when the app is running in the browser.